### PR TITLE
攻撃モーションと当たり判定の調整

### DIFF
--- a/Assets/Animations/Player/Animator.controller
+++ b/Assets/Animations/Player/Animator.controller
@@ -33,22 +33,22 @@ AnimatorStateMachine:
   m_ChildStates:
   - serializedVersion: 1
     m_State: {fileID: -4252092152329611263}
-    m_Position: {x: 680, y: 260, z: 0}
+    m_Position: {x: 580, y: 260, z: 0}
   - serializedVersion: 1
     m_State: {fileID: -3084865332352395634}
-    m_Position: {x: 680, y: 340, z: 0}
+    m_Position: {x: 580, y: 340, z: 0}
   - serializedVersion: 1
     m_State: {fileID: -5561244527012716086}
-    m_Position: {x: 430, y: 180, z: 0}
+    m_Position: {x: 350, y: 180, z: 0}
   - serializedVersion: 1
     m_State: {fileID: -4798805477078974433}
-    m_Position: {x: 740, y: 40, z: 0}
+    m_Position: {x: 830, y: 40, z: 0}
   - serializedVersion: 1
     m_State: {fileID: 4099176179887207096}
-    m_Position: {x: 430, y: 40, z: 0}
+    m_Position: {x: 350, y: 40, z: 0}
   - serializedVersion: 1
     m_State: {fileID: -6331858130739580478}
-    m_Position: {x: 430, y: 110, z: 0}
+    m_Position: {x: 580, y: 110, z: 0}
   m_ChildStateMachines: []
   m_AnyStateTransitions:
   - {fileID: -202957077324317073}
@@ -58,7 +58,7 @@ AnimatorStateMachine:
   m_StateMachineBehaviours: []
   m_AnyStatePosition: {x: 180, y: -50, z: 0}
   m_EntryPosition: {x: 170, y: 270, z: 0}
-  m_ExitPosition: {x: 830, y: -10, z: 0}
+  m_ExitPosition: {x: 920, y: -40, z: 0}
   m_ParentStateMachinePosition: {x: 800, y: 20, z: 0}
   m_DefaultState: {fileID: -4252092152329611263}
 --- !u!1102 &-6331858130739580478
@@ -99,6 +99,9 @@ AnimatorStateTransition:
   - m_ConditionMode: 3
     m_ConditionEvent: Speed
     m_EventTreshold: 0.1
+  - m_ConditionMode: 1
+    m_ConditionEvent: IsGrounded
+    m_EventTreshold: 0
   m_DstStateMachine: {fileID: 0}
   m_DstState: {fileID: -3084865332352395634}
   m_Solo: 0
@@ -206,6 +209,9 @@ AnimatorStateTransition:
   - m_ConditionMode: 4
     m_ConditionEvent: Speed
     m_EventTreshold: 0.1
+  - m_ConditionMode: 1
+    m_ConditionEvent: IsGrounded
+    m_EventTreshold: 0
   m_DstStateMachine: {fileID: 0}
   m_DstState: {fileID: -4252092152329611263}
   m_Solo: 0
@@ -383,6 +389,31 @@ AnimatorStateTransition:
   m_InterruptionSource: 0
   m_OrderedInterruption: 1
   m_CanTransitionToSelf: 1
+--- !u!1101 &2237057231951357771
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 1
+    m_ConditionEvent: IsGrounded
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: -5561244527012716086}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0.25
+  m_TransitionOffset: 0
+  m_ExitTime: 0
+  m_HasExitTime: 0
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
 --- !u!1101 &2320584030347213418
 AnimatorStateTransition:
   m_ObjectHideFlags: 1
@@ -451,6 +482,7 @@ AnimatorState:
   m_CycleOffset: 0
   m_Transitions:
   - {fileID: 2562026534587905486}
+  - {fileID: 2237057231951357771}
   m_StateMachineBehaviours: []
   m_Position: {x: 50, y: 50, z: 0}
   m_IKOnFeet: 0

--- a/Assets/Animations/Player/Attack1.anim
+++ b/Assets/Animations/Player/Attack1.anim
@@ -36,8 +36,6 @@ AnimationClip:
       value: {fileID: 4804923502247703499, guid: ae72133dacba6ec4eb33ecde48f50e56, type: 3}
     - time: 0.46666667
       value: {fileID: -6253208296904073923, guid: ae72133dacba6ec4eb33ecde48f50e56, type: 3}
-    - time: 0.53333336
-      value: {fileID: -7879541775824577086, guid: ae72133dacba6ec4eb33ecde48f50e56, type: 3}
     attribute: m_Sprite
     path: 
     classID: 212
@@ -68,13 +66,12 @@ AnimationClip:
     - {fileID: -6211648682532063752, guid: ae72133dacba6ec4eb33ecde48f50e56, type: 3}
     - {fileID: 4804923502247703499, guid: ae72133dacba6ec4eb33ecde48f50e56, type: 3}
     - {fileID: -6253208296904073923, guid: ae72133dacba6ec4eb33ecde48f50e56, type: 3}
-    - {fileID: -7879541775824577086, guid: ae72133dacba6ec4eb33ecde48f50e56, type: 3}
   m_AnimationClipSettings:
     serializedVersion: 2
     m_AdditiveReferencePoseClip: {fileID: 0}
     m_AdditiveReferencePoseTime: 0
     m_StartTime: 0
-    m_StopTime: 0.6
+    m_StopTime: 0.53333336
     m_OrientationOffsetY: 0
     m_Level: 0
     m_CycleOffset: 0
@@ -101,7 +98,28 @@ AnimationClip:
     floatParameter: 0
     intParameter: 4
     messageOptions: 0
-  - time: 0.53333336
+  - time: 0.26666668
+    functionName: PlayArmor
+    data: 
+    objectReferenceParameter: {fileID: 0}
+    floatParameter: 0
+    intParameter: 0
+    messageOptions: 0
+  - time: 0.33333334
+    functionName: PlayAttack1
+    data: 
+    objectReferenceParameter: {fileID: 0}
+    floatParameter: 0
+    intParameter: 0
+    messageOptions: 0
+  - time: 0.4
+    functionName: PlayAttack1
+    data: 
+    objectReferenceParameter: {fileID: 0}
+    floatParameter: 0
+    intParameter: 0
+    messageOptions: 0
+  - time: 0.46666667
     functionName: EndAttack
     data: 
     objectReferenceParameter: {fileID: 0}

--- a/Assets/Animations/Player/Jump.anim
+++ b/Assets/Animations/Player/Jump.anim
@@ -86,3 +86,10 @@ AnimationClip:
     floatParameter: 0
     intParameter: 3
     messageOptions: 0
+  - time: 0.033333335
+    functionName: PlayArmor
+    data: 
+    objectReferenceParameter: {fileID: 0}
+    floatParameter: 0
+    intParameter: 0
+    messageOptions: 0

--- a/Assets/Animations/Player/Land.anim
+++ b/Assets/Animations/Player/Land.anim
@@ -92,8 +92,8 @@ AnimationClip:
     floatParameter: 0
     intParameter: 2
     messageOptions: 0
-  - time: 0
-    functionName: 
+  - time: 0.016666668
+    functionName: PlayArmor
     data: 
     objectReferenceParameter: {fileID: 0}
     floatParameter: 0

--- a/Assets/Animations/Player/Run.anim
+++ b/Assets/Animations/Player/Run.anim
@@ -91,8 +91,22 @@ AnimationClip:
   m_HasGenericRootTransform: 0
   m_HasMotionFloatCurves: 0
   m_Events:
+  - time: 0.083333336
+    functionName: PlayArmor
+    data: 
+    objectReferenceParameter: {fileID: 0}
+    floatParameter: 0
+    intParameter: 0
+    messageOptions: 0
   - time: 0.16666667
     functionName: PlayFootstepLeft
+    data: 
+    objectReferenceParameter: {fileID: 0}
+    floatParameter: 0
+    intParameter: 0
+    messageOptions: 0
+  - time: 0.41666666
+    functionName: PlayArmor
     data: 
     objectReferenceParameter: {fileID: 0}
     floatParameter: 0

--- a/Assets/Date/Player/Attack1.asset
+++ b/Assets/Date/Player/Attack1.asset
@@ -1,0 +1,21 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b0e94889263dcc341a28a650d6e473e0, type: 3}
+  m_Name: Attack1
+  m_EditorClassIdentifier: 
+  attackName: Attack1
+  startSize: {x: 0, y: 0}
+  maxSize: {x: 2, y: 2}
+  offset: {x: 1, y: 1.5, z: 0}
+  startTime: 0
+  maxTime: 0
+  damage: 1

--- a/Assets/Date/Player/Attack1.asset.meta
+++ b/Assets/Date/Player/Attack1.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a48ef4be4e4628646b80dd126f73d382
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Date/Player/Attack2.asset
+++ b/Assets/Date/Player/Attack2.asset
@@ -1,0 +1,20 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b0e94889263dcc341a28a650d6e473e0, type: 3}
+  m_Name: Attack2
+  m_EditorClassIdentifier: 
+  name: 
+  startSize: {x: 0, y: 0}
+  maxSize: {x: 0, y: 0}
+  startTime: 0
+  maxTime: 0
+  damage: 0

--- a/Assets/Date/Player/Attack2.asset.meta
+++ b/Assets/Date/Player/Attack2.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 11604fdb39672284f9eed078d2c7d820
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Date/Player/Attack3.asset
+++ b/Assets/Date/Player/Attack3.asset
@@ -1,0 +1,20 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b0e94889263dcc341a28a650d6e473e0, type: 3}
+  m_Name: Attack3
+  m_EditorClassIdentifier: 
+  name: 
+  startSize: {x: 0, y: 0}
+  maxSize: {x: 0, y: 0}
+  startTime: 0
+  maxTime: 0
+  damage: 0

--- a/Assets/Date/Player/Attack3.asset.meta
+++ b/Assets/Date/Player/Attack3.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: de7948d4f198836449f3144ee7c114d0
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Date/Player/DashAttack.asset
+++ b/Assets/Date/Player/DashAttack.asset
@@ -1,0 +1,20 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b0e94889263dcc341a28a650d6e473e0, type: 3}
+  m_Name: DashAttack
+  m_EditorClassIdentifier: 
+  name: 
+  startSize: {x: 0, y: 0}
+  maxSize: {x: 0, y: 0}
+  startTime: 0
+  maxTime: 0
+  damage: 0

--- a/Assets/Date/Player/DashAttack.asset.meta
+++ b/Assets/Date/Player/DashAttack.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8328ef06eb63a3640b681cd9f29a7e62
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -164,6 +164,7 @@ GameObject:
   m_Component:
   - component: {fileID: 40050606}
   - component: {fileID: 40050605}
+  - component: {fileID: 40050610}
   - component: {fileID: 40050603}
   - component: {fileID: 40050608}
   - component: {fileID: 40050607}
@@ -189,7 +190,12 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   moveSpeed: 10
   jumpForce: 21
-  hitBox: {fileID: 409576165}
+  hitBox: {fileID: 409576167}
+  attack1: {fileID: 11400000, guid: a48ef4be4e4628646b80dd126f73d382, type: 2}
+  attack2: {fileID: 11400000, guid: 11604fdb39672284f9eed078d2c7d820, type: 2}
+  attack3: {fileID: 11400000, guid: de7948d4f198836449f3144ee7c114d0, type: 2}
+  dashAttack: {fileID: 11400000, guid: 8328ef06eb63a3640b681cd9f29a7e62, type: 2}
+  landCooldown: 0.1
   groundCheck: {fileID: 605645831}
   groundRadius: 0.35
   groundLayer:
@@ -364,6 +370,21 @@ Animator:
   m_AllowConstantClipSamplingOptimization: 1
   m_KeepAnimatorStateOnDisable: 0
   m_WriteDefaultValuesOnDisable: 0
+--- !u!114 &40050610
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 40050602}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c6f8ffaeeb652664c83e0a3768fdbef2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  maxHp: 100
+  attackPower: 100
+  skillPoint: 0
 --- !u!1 &45727152
 GameObject:
   m_ObjectHideFlags: 0
@@ -1216,6 +1237,7 @@ GameObject:
   m_Component:
   - component: {fileID: 409576166}
   - component: {fileID: 409576165}
+  - component: {fileID: 409576167}
   m_Layer: 0
   m_Name: HitBox
   m_TagString: Untagged
@@ -1253,7 +1275,7 @@ CircleCollider2D:
   m_CallbackLayers:
     serializedVersion: 2
     m_Bits: 4294967295
-  m_IsTrigger: 0
+  m_IsTrigger: 1
   m_UsedByEffector: 0
   m_CompositeOperation: 0
   m_CompositeOrder: 0
@@ -1268,12 +1290,24 @@ Transform:
   m_GameObject: {fileID: 409576164}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0.107221395, y: 1.07, z: 0.69597673}
+  m_LocalPosition: {x: 0.107221395, y: 1.07, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 40050606}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &409576167
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 409576164}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: eebe54b4a3471534e9cf4c3942ce8b70, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &417495556
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -2051,7 +2085,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   footstepSource: {fileID: 806955361}
   oneShotSource: {fileID: 806955362}
-  armorVolume: 6.2
+  armorVolume: 15
   armorClips:
   - {fileID: 8300000, guid: 9c2e1669bdda87e4d8a70d73936f5d44, type: 3}
   - {fileID: 8300000, guid: 8701a12c2da1d2849a242a13d7c44ce7, type: 3}
@@ -2073,8 +2107,8 @@ MonoBehaviour:
   - {fileID: 8300000, guid: cf3174f518070814082b12f2b2741266, type: 3}
   - {fileID: 8300000, guid: 539feb6cab8e1b841a382a48a36d9b63, type: 3}
   - {fileID: 8300000, guid: 958f4a5ab9402b146a5dd7f9800fcc97, type: 3}
-  jumpVolume: 40
-  jump: {fileID: 8300000, guid: dd310729612303a44b8f61a184217788, type: 3}
+  jumpVolume: 20
+  jump: {fileID: 8300000, guid: 5629e641b4ad2d34bb0e380c4c5f9244, type: 3}
   landVolume: 40
   land: {fileID: 8300000, guid: 19a30200589813c48a2e0df19f950f60, type: 3}
   attackVolume: 40
@@ -2092,7 +2126,7 @@ AudioSource:
   m_audioClip: {fileID: 0}
   m_Resource: {fileID: 0}
   m_PlayOnAwake: 0
-  m_Volume: 0.226
+  m_Volume: 0.2
   m_Pitch: 1
   Loop: 0
   Mute: 0
@@ -2189,7 +2223,7 @@ AudioSource:
   m_audioClip: {fileID: 0}
   m_Resource: {fileID: 0}
   m_PlayOnAwake: 1
-  m_Volume: 1
+  m_Volume: 0.2
   m_Pitch: 1
   Loop: 0
   Mute: 0

--- a/Assets/Scripts/AttackData.cs
+++ b/Assets/Scripts/AttackData.cs
@@ -1,0 +1,15 @@
+using UnityEngine;
+
+[CreateAssetMenu(menuName = "Combat/Attack Data")]
+public class AttackData : ScriptableObject
+{
+    public string attackName;
+    public Vector2 startSize;
+    public Vector2 maxSize;
+    public Vector3 offset;
+
+    public float startTime;
+    public float maxTime;
+
+    public int damage;
+}

--- a/Assets/Scripts/AttackData.cs.meta
+++ b/Assets/Scripts/AttackData.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: b0e94889263dcc341a28a650d6e473e0

--- a/Assets/Scripts/AttackHitbox.cs
+++ b/Assets/Scripts/AttackHitbox.cs
@@ -1,0 +1,77 @@
+using UnityEngine;
+using System.Collections;
+
+public class AttackHitbox : MonoBehaviour
+{
+    private Collider2D col;
+    private AttackData data;
+    private Coroutine routine;
+    private Vector2 debugSize;
+
+    private void Awake()
+    {
+        col = GetComponent<Collider2D>();
+        col.enabled = false;
+    }
+
+    public void Play(AttackData attackData)
+    {
+        data = attackData;
+
+        StopAllCoroutines();
+        StartCoroutine(Run());
+    }
+
+    private IEnumerator Run()
+    {
+        col.enabled = true;
+
+        // 小判定
+        SetSize(data.startSize);
+        yield return new WaitForSeconds(data.startTime);
+
+        // 最大判定
+        SetSize(data.maxSize);
+        yield return new WaitForSeconds(data.maxTime);
+
+        // 終了
+        col.enabled = false;
+    }
+
+    private void OnTriggerEnter2D(Collider2D collision)
+    {
+        if (data == null) return;
+        if (collision.TryGetComponent<Enemy>(out var enemy))
+        {
+            int damage = data.damage * Player.Instance.AttackPower;
+            enemy.TakeDamage(damage);
+            Debug.Log($"敵にヒット！ ダメージ: {damage}");
+        }
+    }
+
+    private void SetSize(Vector2 size)
+    {
+        debugSize = size;
+        if (col is BoxCollider2D box)
+        {
+            box.size = size;
+        }
+        float dir = Mathf.Sign(transform.root.localScale.x);
+
+        transform.localPosition = new Vector3(
+        data.offset.x * dir,
+        data.offset.y,
+        0);
+    }
+
+    private void OnDrawGizmos()
+    {
+        if (!Application.isPlaying) return;
+
+        Gizmos.color = Color.red;
+
+        Vector3 pos = transform.position;
+
+        Gizmos.DrawWireCube(pos, new Vector3(debugSize.x, debugSize.y, 0));
+    }
+}

--- a/Assets/Scripts/AttackHitbox.cs.meta
+++ b/Assets/Scripts/AttackHitbox.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: eebe54b4a3471534e9cf4c3942ce8b70

--- a/Assets/Scripts/Enemy.cs
+++ b/Assets/Scripts/Enemy.cs
@@ -16,6 +16,11 @@ public class Enemy : Unit
         base.Start();
     }
 
+    public override void TakeDamage(int damage)
+    {
+        base.TakeDamage(damage);
+    }
+
     // 敵が死亡した場合、SkillPointを渡す
     protected override void Die()
     {

--- a/Assets/Scripts/Player.cs
+++ b/Assets/Scripts/Player.cs
@@ -4,7 +4,7 @@ public class Player : MonoBehaviour
 {
     public static Player Instance;
     [SerializeField] private int maxHp = 100;
-    [SerializeField] private int attackPower = 10; // Playerの攻撃力
+    [SerializeField] private int attackPower = 100; // Playerの攻撃力
 
     private int currentHp;
     public int AttackPower => attackPower;

--- a/Assets/Scripts/PlayerController.cs
+++ b/Assets/Scripts/PlayerController.cs
@@ -7,7 +7,11 @@ public class PlayerController : MonoBehaviour
     [SerializeField] private float jumpForce = 20f;
 
     [Header("Attack")]
-    [SerializeField] private Collider2D hitBox; 
+    [SerializeField] private AttackHitbox hitBox;
+    [SerializeField] private AttackData attack1;
+    [SerializeField] private AttackData attack2;
+    [SerializeField] private AttackData attack3;
+    [SerializeField] private AttackData dashAttack;
 
     [Header("Ground Check")]
     [SerializeField] private float landCooldown = 0.1f;
@@ -26,14 +30,15 @@ public class PlayerController : MonoBehaviour
     private Animator animator;
     private Player player;
 
+    private bool isGrounded;
     private bool landLocked;
+    private bool wasGrounded;
     private float landLockTime;
 
     private float moveInput;
     private bool jumpRequest;
-    private bool isGrounded;
     private bool isAttacking;
-    private bool wasGrounded;
+    
 
     private void Awake()
     {
@@ -41,8 +46,6 @@ public class PlayerController : MonoBehaviour
         spriteRenderer = GetComponent<SpriteRenderer>();
         animator = GetComponent<Animator>();
         player = GetComponent<Player>();
-
-        hitBox.enabled = false;
     }
 
     private void Update()
@@ -151,24 +154,16 @@ public class PlayerController : MonoBehaviour
             Debug.Log("攻撃入力無効");
             return;
         }
-
         isAttacking = true;
 
         Debug.Log("Attackアニメーション開始");
         animator.SetTrigger("Attack");
     }
 
-    // --------------------
-    // HitBox制御
-    // --------------------
-    public void EnableHitBox()
+    public void PlayAttack1()
     {
-        hitBox.enabled = true;
-    }
-
-    public void DisableHitBox()
-    {
-        hitBox.enabled = false;
+        Debug.Log("PlayAttack1 呼ばれた");
+        hitBox.Play(attack1);
     }
 
     public void EndAttack()
@@ -194,16 +189,6 @@ public class PlayerController : MonoBehaviour
             Debug.Log("ゲームクリア");
             GameManager.Instance.GameClear();
             return;
-        }
-        
-        if (!hitBox.enabled) return;
-
-        Enemy enemy = collision.GetComponent<Enemy>();
-
-        if (enemy != null)
-        {
-            Debug.Log("敵にヒット");
-            enemy.TakeDamage(Player.Instance.AttackPower);
         }
     }
 


### PR DESCRIPTION
■AttackHitbox
・GetComponentでCollider2Dを取得
・AttackDataを参照

■AttackData
・攻撃の当たり判定をstartSize、maxSize、offsetで設定

■AnimationEvent
・剣を振り下ろす絵にEventを追加しFunctionでPlayAttack1を指定

■PlayerController側の修正
・HitboxをAttackHitboxへ移動
・SerializeFieldでAttackHitboxを取得
・SerializeFieldでAttacDataを取得

■対象にヒットさせる
・EnemyにOnTriggerEnter2DでTakeDamageでヒットさせる

■ダメージ処理
・Playerで攻撃力を持たせる
・int damage = data.damage * Player.Instance.AttackPowerで計算する ・EnemyにTakeDamageを渡す
・Unitでダメージを受けたらHPを減らす